### PR TITLE
'^rst2html.py$' toegevoegd aan security.exec.allow

### DIFF
--- a/config/_default/security.toml
+++ b/config/_default/security.toml
@@ -3,7 +3,7 @@
 enableInlineShortcodes = false
 
 [exec]
-  allow = ['^dart-sass-embedded$', '^go$', '^npx$', '^postcss$', '^rst2html$']
+  allow = ['^dart-sass-embedded$', '^go$', '^npx$', '^postcss$', '^rst2html$', '^rst2html.py$']
   osEnv = ['(?i)^((HTTPS?|NO)_PROXY|PATH(EXT)?|APPDATA|TE?MP|TERM|GO\w+|GIT_EXEC_PATH|LD_LIBRARY_PATH|npm_config_(cache|init_module|userconfig)|pandoc_datadir|PYTHONHOME|RUBYLIB|SNAP)$']
 
 [funcs]


### PR DESCRIPTION
Dit is met name belangrijk voor Mac gebruikers, die macports gebruiken